### PR TITLE
Fix routing to only include private IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ eval $(docker-machine env mybox)
 Also, you should add a route to access containers inside your VM.
 
 ```
-$ sudo route -n add 172.0.0.0/8 $(docker-machine ip $(docker-machine active))
+$ sudo route -n add 172.0.0.0/12 $(docker-machine ip $(docker-machine active))
 ```
 
 ### INSTALL WITH COMPOSER


### PR DESCRIPTION
Previously the README suggested to route all traffic from `172.0.0.0/8` to the Mac docker-machine. 

However, this includes public IP, as the reserved range for the private IPs is `172.0.0.0/12` 
(see [the Wikipedia page](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses))

For example, on my machine, google.com translated to 172.14.x.x, meaning google.com was unreachable using the route suggested in the README